### PR TITLE
Fix clipping and conversion

### DIFF
--- a/calculate_PSNR_SSIM.py
+++ b/calculate_PSNR_SSIM.py
@@ -134,7 +134,7 @@ def bgr2ycbcr(img, only_y=True):
         float, [0, 1]
     '''
     in_img_type = img.dtype
-    img.astype(np.float32)
+    img = img.astype(np.float32)
     if in_img_type != np.uint8:
         img *= 255.
     # convert

--- a/train.py
+++ b/train.py
@@ -185,13 +185,13 @@ try:
                     secret_rev = iwt(secret_rev)
 
                     secret_rev = secret_rev.cpu().numpy().squeeze() * 255
-                    np.clip(secret_rev, 0, 255)
+                    secret_rev = np.clip(secret_rev, 0, 255)
                     secret = secret.cpu().numpy().squeeze() * 255
-                    np.clip(secret, 0, 255)
+                    secret = np.clip(secret, 0, 255)
                     cover = cover.cpu().numpy().squeeze() * 255
-                    np.clip(cover, 0, 255)
+                    cover = np.clip(cover, 0, 255)
                     steg = steg.cpu().numpy().squeeze() * 255
-                    np.clip(steg, 0, 255)
+                    steg = np.clip(steg, 0, 255)
                     psnr_temp = computePSNR(secret_rev, secret)
                     psnr_s.append(psnr_temp)
                     psnr_temp_c = computePSNR(cover, steg)

--- a/train_logging.py
+++ b/train_logging.py
@@ -201,13 +201,13 @@ try:
                     secret_rev = iwt(secret_rev)
 
                     secret_rev = secret_rev.cpu().numpy().squeeze() * 255
-                    np.clip(secret_rev, 0, 255)
+                    secret_rev = np.clip(secret_rev, 0, 255)
                     secret = secret.cpu().numpy().squeeze() * 255
-                    np.clip(secret, 0, 255)
+                    secret = np.clip(secret, 0, 255)
                     cover = cover.cpu().numpy().squeeze() * 255
-                    np.clip(cover, 0, 255)
+                    cover = np.clip(cover, 0, 255)
                     steg = steg.cpu().numpy().squeeze() * 255
-                    np.clip(steg, 0, 255)
+                    steg = np.clip(steg, 0, 255)
                     psnr_temp = computePSNR(secret_rev, secret)
                     psnr_s.append(psnr_temp)
                     psnr_temp_c = computePSNR(cover, steg)


### PR DESCRIPTION
## Summary
- prevent numpy clip results from being dropped in `train.py` and `train_logging.py`
- ensure float conversion actually occurs in `calculate_PSNR_SSIM.py`

## Testing
- `python -m py_compile train.py train_logging.py calculate_PSNR_SSIM.py`

------
https://chatgpt.com/codex/tasks/task_e_687ba29004ac83299ad91352aa7b1874